### PR TITLE
Update listing layout and email functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ For advanced option, you'll need to include the "Email Me" functionality by doin
 7. Enable "Override the output of this field with custom text" under "Rewrite results"
 8. Select the Custom text field.
 9. In the text field, remove the twig comment characters around the {{ view_node }} and {{ view_node_1 }} lines.
-
+10. Edit Directory Entry content type. Select the manage fields tab.
+11. Edit the Email field and check the "Required" box to require an email address entry.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@ Provides Directory Entry content type and related configuration. Directory Entri
 ## Installation
 
 $ composer require tributemedia/tm_directory: ^1.0
+
+## Configuration
+
+For standard configuration (no email functionality), you will need to remove the "Email Me" block from the Right Sidebar region.
+
+For advanced option, you'll need to include the "Email Me" functionality by doing the following. 
+
+1. Edit the Directory Listing Page display in the Directory view.
+2. Select the Name field. 
+3. Uncheck "Link to the Content"
+4. Enable "Output this field as a custom link" under "Rewrite results" 
+5. Select the Picture field.
+6. Select "Nothing" in the "Link image to" drop down.
+7. Enable "Override the output of this field with custom text" under "Rewrite results"
+8. Select the Custom text field.
+9. In the text field, remove the twig comment characters around the {{ view_node }} and {{ view_node_1 }} lines.
+

--- a/config/install/core.base_field_override.node.directory_entry.promote.yml
+++ b/config/install/core.base_field_override.node.directory_entry.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.directory_entry
+id: node.directory_entry.promote
+field_name: promote
+entity_type: node
+bundle: directory_entry
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/core.base_field_override.node.directory_entry.title.yml
+++ b/config/install/core.base_field_override.node.directory_entry.title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.directory_entry
+id: node.directory_entry.title
+field_name: title
+entity_type: node
+bundle: directory_entry
+label: Name
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.node.directory_entry.field_dir_email_address.yml
+++ b/config/install/field.field.node.directory_entry.field_dir_email_address.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: directory_entry
 label: 'Email Address'
 description: 'This email address will be used in the contact form for sending messages to this person.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/install/image.style.directory_listing.yml
+++ b/config/install/image.style.directory_listing.yml
@@ -9,6 +9,6 @@ effects:
     id: image_scale_and_crop
     weight: 1
     data:
-      width: 600
+      width: 514
       height: 600
       anchor: center-center

--- a/config/install/views.view.directory.yml
+++ b/config/install/views.view.directory.yml
@@ -280,7 +280,7 @@ display:
           alter:
             alter_text: false
             text: ''
-            make_link: true
+            make_link: false
             path: '{{ view_node_2 }}?mail_to={{ field_dir_email_address }}'
             absolute: false
             external: false
@@ -319,7 +319,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: false
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -467,7 +467,7 @@ display:
           label: ''
           exclude: true
           alter:
-            alter_text: true
+            alter_text: false
             text: "<div class=\"directory-img\"><a href=\"{{ view_node_2 }}?mail_to={{ field_dir_email_address }}\">{{ field_dir_picture }}</a></div>\r\n"
             make_link: false
             path: ''
@@ -508,14 +508,12 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_link: ''
+            image_link: content
             image_style: directory_listing
             svg_attributes:
               width: null
               height: null
             svg_render_as_image: true
-            image_loading:
-              attribute: lazy
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -654,7 +652,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"employee-wrapper\">\r\n{{ field_dir_picture }}\r\n<div class=\"directory-info\">\r\n<div class=\"directory-name\">{{ title }}</div>\r\n{{ field_dir_professional_title }}\r\n{{ field_dir_phone }}\r\n{{ view_node }}\r\n</div>\r\n{{ view_node_1 }}\r\n</div>"
+            text: "<div class=\"employee-wrapper\">\r\n{{ field_dir_picture }}\r\n<div class=\"directory-info\">\r\n<div class=\"directory-name\">{{ title }}</div>\r\n{{ field_dir_professional_title }}\r\n{{ field_dir_phone }}\r\n{# {{ view_node }} #}\r\n</div>\r\n{# {{ view_node_1 }} #}\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -809,7 +807,7 @@ display:
               field: field_entry_type
               rendered: true
               rendered_strip: false
-          row_class: 'col-12 col-md-6'
+          row_class: 'col-12 col-md-6 col-lg-4 col-xl-3'
           default_row_class: true
       row:
         type: fields

--- a/css/directory.css
+++ b/css/directory.css
@@ -154,6 +154,11 @@ div.bio-link::before {
   transition: all 0.2s ease-in-out;
 }
 
+.field-dir-social-media {
+	display:inline-block;
+	margin-bottom:10px;
+}
+
 /* ======================= */
 /* = Directory Node View = */
 /* ======================= */


### PR DESCRIPTION
- Changed listing layout to 4 columns and change listing image style to show 1:1 ratio. 
- Removed email functionality from the default configurations. 
- Updated README.md to include configuration instructions.